### PR TITLE
Only mark badges as print_pending if they haven't been printed already

### DIFF
--- a/badge_printing/models.py
+++ b/badge_printing/models.py
@@ -37,7 +37,8 @@ class Attendee:
     @presave_adjustment
     def print_ready_before_event(self):
         if c.PRE_CON:
-            if self.badge_status == c.COMPLETED_STATUS and not self.is_not_ready_to_checkin:
+            if self.badge_status == c.COMPLETED_STATUS and not self.is_not_ready_to_checkin\
+                    and self.times_printed < 1:
                 self.print_pending = True
 
     @presave_adjustment


### PR DESCRIPTION
This fixes an (undiscovered) bug where the server would try to print a badge again after it's already been printed, because it didn't account for a badge already having been printed.