### PR TITLE
Always require a reason for a free badge reprint

### DIFF
--- a/badge_printing/site_sections/kiosk_printing.py
+++ b/badge_printing/site_sections/kiosk_printing.py
@@ -63,7 +63,7 @@ class Root:
     def reprint_fee(self, session, attendee_id=None, message='', fee_amount=0, reprint_reason='', refund=''):
         attendee = session.attendee(attendee_id)
         fee_amount = int(fee_amount)
-        if not fee_amount and not reprint_reason and c.BADGE_REPRINT_FEE:
+        if not fee_amount and not reprint_reason:
             message = "You must charge a fee or enter a reason for a free reprint!"
         if not fee_amount and refund:
             message = "You can't refund a fee of $0!"

--- a/badge_printing/templates/regextra.html
+++ b/badge_printing/templates/regextra.html
@@ -9,7 +9,7 @@
         <div id="print_pending" class="form-group">
             <label for="print_pending" class="col-sm-2 control-label">Ready to Print</label>
             <div class="col-sm-6">
-                {{ macros.checkbox(attendee, 'print_pending') }}
+                {{ attendee.print_pending|yesno }}
             </div>
         </div>
     {% endif %}


### PR DESCRIPTION
The code wanted an event to set the BADGE_REPRINT_FEE before it would enforce the need for a reason to do a free reprint. Since we're have issues with volunteers accidentally or unknowingly reprinting badges, this changes it so that a reason is always required for a free reprint.