### PR TITLE
Accommodate new multichoice column for ribbons

### DIFF
--- a/badge_printing/models.py
+++ b/badge_printing/models.py
@@ -36,11 +36,6 @@ class SessionMixin:
         except StopIteration:
             return None
 
-        attendee.times_printed += 1
-        attendee.print_pending = False
-        self.add(attendee)
-        self.commit()
-
         return attendee
 
 

--- a/badge_printing/site_sections/kiosk_printing.py
+++ b/badge_printing/site_sections/kiosk_printing.py
@@ -59,8 +59,12 @@ class Root:
         except Exception:
             pass
 
-        ribbon = attendee.ribbon_label if attendee.ribbon != c.NO_RIBBON \
-            else ''
+        ribbon = ' / '.join(attendee.ribbon_labels) if attendee.ribbon else ''
+
+        attendee.times_printed += 1
+        attendee.print_pending = False
+        session.add(attendee)
+        session.commit()
 
         return {
             'badge_type': badge_type,


### PR DESCRIPTION
Fixes https://github.com/MidwestFurryFandom/badge_printing/issues/11. We also now mark an attendee as printed right before we load the page, rather than before we do any processing of the badge.