### PR TITLE
Update migration comment

### DIFF
--- a/alembic/versions/af64b33e950a_initial_migration.py
+++ b/alembic/versions/af64b33e950a_initial_migration.py
@@ -1,7 +1,7 @@
 """Initial migration
 
 Revision ID: af64b33e950a
-Revises: 735063d71b57
+Revises: 1ed43776064f
 Create Date: 2018-05-08 23:18:35.150928
 
 """


### PR DESCRIPTION
Not entirely sure this does anything, but we noticed while sorting out our database migrations that some of our plugin migrations had a file name different from their actual revision ID. This was the only plugin with the correct filename, but it had the wrong "Revises" ID.