### PR TITLE
Call correct function for assigning a badge number after payment

### DIFF
--- a/badge_printing/models.py
+++ b/badge_printing/models.py
@@ -46,7 +46,7 @@ class Attendee:
             if self.has_personalized_badge and not self.badge_num:
                 if self.paid != c.NOT_PAID:
                     self.badge_num = self.session\
-                        .next_badge_num(self.badge_type, old_badge_num=0)
+                        .get_next_badge_num(self.badge_type)
 
     @presave_adjustment
     def print_ready_before_event(self):


### PR DESCRIPTION
We didn't catch this before because almost all badges are assigned a badge number BEFORE payment, but this presave adjustment was causing a 500 error in the very, very, *very* rare case where there was no pre-existing badge number. It's so rare that I can't reproduce it, but this should fix it in any case.